### PR TITLE
fix: resolve two crash/stability bugs in MQTT and HA discovery

### DIFF
--- a/components/geappliances_bridge/esphome_mqtt_client_adapter.cpp
+++ b/components/geappliances_bridge/esphome_mqtt_client_adapter.cpp
@@ -11,12 +11,13 @@ extern "C" {
 #include <cstdio>
 #include <string>
 #include <cctype>
-#include <deque>
+#include <map>
 
 static const char *const TAG = "geappliances_bridge.mqtt";
 
-// Maximum number of pending updates to queue (prevent memory exhaustion)
-static constexpr size_t MAX_PENDING_UPDATES = 100;
+// Maximum number of distinct ERDs that can be pending (safety bound — in
+// practice bounded by the number of ERDs the appliance registers, typically <100).
+static constexpr size_t MAX_PENDING_UPDATES = 200;
 
 static std::string build_topic(esphome_mqtt_client_adapter_t* self, const char* suffix)
 {
@@ -146,10 +147,13 @@ static void update_erd(i_mqtt_client_t* _self, tiny_erd_t erd, const void* value
   if (mqtt_client != nullptr && mqtt_client->is_connected()) {
     mqtt_client->publish(topic, payload, 2, true);  // QoS 2, retain
   } else {
-    // Queue the update for later when MQTT connects
+    // Queue the update for later when MQTT connects. The map key is the ERD so
+    // a repeated update overwrites the previous pending value instead of
+    // appending — this prevents the queue from filling with stale duplicates
+    // across multiple polling cycles while MQTT is down.
     if (self->pending_updates != nullptr && self->pending_updates->size() < MAX_PENDING_UPDATES) {
-      self->pending_updates->push_back({topic, payload});
-      ESP_LOGD(TAG, "MQTT not connected, queued ERD update for 0x%04X (queue size: %zu)", 
+      (*self->pending_updates)[erd] = {topic, payload};
+      ESP_LOGD(TAG, "MQTT not connected, queued ERD update for 0x%04X (queue size: %zu)",
                erd, self->pending_updates->size());
     } else if (self->pending_updates == nullptr) {
       ESP_LOGW(TAG, "Pending updates queue not initialized, dropping ERD update for 0x%04X", erd);
@@ -214,7 +218,7 @@ extern "C" void esphome_mqtt_client_adapter_init(
 {
   self->interface.api = &api;
   self->device_id = new std::string(device_id);
-  self->pending_updates = new std::deque<PendingErdUpdate>();
+  self->pending_updates = new std::map<tiny_erd_t, PendingErdUpdate>();
   self->valid_erds_filter = nullptr;
   self->string_erds_filter = nullptr;
   self->registered_erds_out = nullptr;
@@ -255,14 +259,17 @@ extern "C" void esphome_mqtt_client_adapter_notify_disconnected(
 extern "C" void esphome_mqtt_client_adapter_notify_connected(
   esphome_mqtt_client_adapter_t* self)
 {
-  // Flush pending updates when MQTT connects
+  // Flush pending updates when MQTT connects.
+  // Use QoS-0 (fire-and-forget) so publishing the full map in one go does not
+  // generate PUBREC/PUBREL/PUBCOMP handshake events for every message; the
+  // retained flag still ensures the broker persists the latest value.
   auto mqtt_client = esphome::mqtt::global_mqtt_client;
   if (mqtt_client != nullptr && mqtt_client->is_connected() && 
       self->pending_updates != nullptr && !self->pending_updates->empty()) {
     ESP_LOGI(TAG, "MQTT connected, flushing %zu pending ERD updates", self->pending_updates->size());
     
-    for (const auto& update : *self->pending_updates) {
-      mqtt_client->publish(update.topic, update.payload, 2, true);  // QoS 2, retain
+    for (const auto& kv : *self->pending_updates) {
+      mqtt_client->publish(kv.second.topic, kv.second.payload, 0, true);  // QoS 0, retain
     }
     
     self->pending_updates->clear();

--- a/components/geappliances_bridge/esphome_mqtt_client_adapter.h
+++ b/components/geappliances_bridge/esphome_mqtt_client_adapter.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <string>
-#include <deque>
+#include <map>
 #include <set>
 
 extern "C" {
@@ -19,7 +19,10 @@ typedef struct {
   std::string* device_id;
   tiny_event_t on_write_request_event;
   tiny_event_t on_mqtt_disconnect_event;
-  std::deque<PendingErdUpdate>* pending_updates;
+  // Keyed by ERD so repeated updates while MQTT is down keep only the latest
+  // value per ERD. This prevents the queue from filling with duplicates during
+  // a polling reconnect cycle and bounds its size to the number of distinct ERDs.
+  std::map<tiny_erd_t, PendingErdUpdate>* pending_updates;
   // Optional filter: when non-null, update_erd only publishes ERDs that are
   // present in this set. Used when appliance_api_parsing is enabled.
   const std::set<tiny_erd_t>* valid_erds_filter;

--- a/components/geappliances_bridge/geappliances_bridge.h
+++ b/components/geappliances_bridge/geappliances_bridge.h
@@ -236,6 +236,11 @@ class GeappliancesBridge : public Component {
   // adapter's register_erd callback). Used to filter HA discovery entities so
   // only ERDs actually supported by the connected device are published.
   std::set<tiny_erd_t> ha_registered_erds_;
+  // Immutable snapshot of ha_registered_erds_ taken just before the HA
+  // discovery FreeRTOS task is spawned.  The background task reads ONLY this
+  // copy so it never races with concurrent insert() calls on ha_registered_erds_
+  // from the main loop (e.g. new subscription ERDs arriving during the fetch).
+  std::set<tiny_erd_t> ha_registered_erds_snapshot_;
   // Set of string-type ERD IDs built from ha_discovery_config.h at bridge init.
   // Passed to the MQTT adapter so it can publish ASCII text instead of hex.
   std::set<tiny_erd_t> ha_string_erds_set_;

--- a/components/geappliances_bridge/geappliances_bridge_ha_discovery.cpp
+++ b/components/geappliances_bridge/geappliances_bridge_ha_discovery.cpp
@@ -147,10 +147,16 @@ void GeappliancesBridge::publish_ha_discovery_()
     return;
   }
 
+  // Snapshot the registered-ERD set before spawning the background task.
+  // The task reads this snapshot exclusively so it never races with concurrent
+  // ha_registered_erds_.insert() calls from the main loop (e.g. new
+  // subscription ERDs arriving while the HTTPS fetch is in progress).
+  this->ha_registered_erds_snapshot_ = this->ha_registered_erds_;
+
   this->ha_discovery_pending_             = false;
   this->ha_discovery_publish_in_progress_ = true;
   ESP_LOGI(TAG, "HA discovery: starting — %zu ERDs registered, launching fetch task",
-           this->ha_registered_erds_.size());
+           this->ha_registered_erds_snapshot_.size());
 
   // Stack size 12 KB – enough for HTTPS + cJSON on ESP32.
   // Priority 1: below IDF MQTT task (5) so MQTT events are not starved while
@@ -243,7 +249,7 @@ void GeappliancesBridge::fetch_ha_definitions_()
 
   bool need[10] = {};
   need[0] = true;  // common — always needed
-  for (uint16_t erd : this->ha_registered_erds_) {
+  for (uint16_t erd : this->ha_registered_erds_snapshot_) {
     for (int i = 1; i < 10; ++i) {
       if (erd >= CATS[i].lo && erd <= CATS[i].hi) { need[i] = true; break; }
     }
@@ -369,13 +375,13 @@ bool GeappliancesBridge::process_jsonl_line_(const char* line,
   const char* paired = get_str("p");
 
   // Filter: only publish entities for ERDs the device actually registered.
-  if (!this->ha_registered_erds_.empty()) {
-    bool registered = this->ha_registered_erds_.count(erd_id) > 0;
+  if (!this->ha_registered_erds_snapshot_.empty()) {
+    bool registered = this->ha_registered_erds_snapshot_.count(erd_id) > 0;
     if (!registered && role[0] == 'r' && paired[0] != '\0') {
       uint16_t paired_id = static_cast<uint16_t>(strtol(paired, nullptr, 16));
       if (paired_id)
-        registered = this->ha_registered_erds_.count(paired_id) > 0 ||
-                     this->ha_registered_erds_.count(erd_id) > 0;
+        registered = this->ha_registered_erds_snapshot_.count(paired_id) > 0 ||
+                     this->ha_registered_erds_snapshot_.count(erd_id) > 0;
     }
     if (!registered) { cJSON_Delete(root); return false; }
   }


### PR DESCRIPTION
## Changes

### Fix 1 — Data race on `ha_registered_erds_` causing `_Rb_tree` crash

**Symptom:** ESP32-C3 crashes in `std::_Rb_tree<unsigned short, ...>::_M_erase()`, detected on next boot by the crash handler.

**Root cause:** The `ha_fetch` FreeRTOS background task was reading `ha_registered_erds_` (a `std::set<uint16_t>`) while the main loop task concurrently called `register_erd()` → `ha_registered_erds_.insert()` (e.g. new subscription ERDs arriving during the HTTPS fetch). Concurrent mutation and traversal of the underlying red-black tree corrupts its internal structure.

**Fix:** Snapshot `ha_registered_erds_` into `ha_registered_erds_snapshot_` immediately before spawning the task (on the main loop, no race). The task now reads exclusively from the immutable snapshot.

Files changed: `geappliances_bridge.h`, `geappliances_bridge_ha_discovery.cpp`

---

### Fix 2 — Pending ERD update queue fills with duplicates; flush floods MQTT event queue

**Symptom:** During an ~15s MQTT disconnect, the pending updates queue fills to 100 items and starts dropping ERD updates. On reconnect, `Dropped 469 inbound MQTT events` is logged.

**Root cause (queue full):** `pending_updates` was a `deque` that appended a new entry per ERD per polling cycle. 3 polling cycles × 33 ERDs = ~99 entries, hitting the 100-item hard cap.

**Root cause (dropped events):** On reconnect, all 100 items were published at QoS-2 in a tight loop. Each QoS-2 publish requires a PUBREC → PUBREL → PUBCOMP handshake, generating ~300 IDF MQTT events that overflow the event queue.

**Fix:**
- Replace `deque<PendingErdUpdate>` with `map<tiny_erd_t, PendingErdUpdate>` — each ERD holds only its latest pending value. The map size is bounded by the number of registered ERDs (~53), so the queue can never fill with duplicates.
- Flush on reconnect uses QoS-0 with `retain=true`. The broker still persists the latest value, but no handshake events are generated.

Files changed: `esphome_mqtt_client_adapter.h`, `esphome_mqtt_client_adapter.cpp`