### PR TITLE
bump: increase max custom ERDs from 64 to 128

### DIFF
--- a/components/geappliances_bridge/__init__.py
+++ b/components/geappliances_bridge/__init__.py
@@ -138,7 +138,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_GENERATE_DEVICE_CONFIG, default=True): cv.boolean,
         cv.Optional(CONF_CUSTOM_ERDS, default=[]): cv.All(cv.ensure_list(
             cv.int_range(min=0, max=0xFFFF)
-        ), cv.Length(max=64)),
+        ), cv.Length(max=128)),
         cv.Optional(CONF_THROTTLE_RATE_SECONDS, default=1): cv.int_range(min=0, max=255),
         cv.Optional(CONF_ERD_PUBLISH_RATE_SENSOR, default=True): cv.Any(
             cv.boolean,

--- a/components/geappliances_bridge/geappliances_bridge.h
+++ b/components/geappliances_bridge/geappliances_bridge.h
@@ -220,7 +220,7 @@ class GeappliancesBridge : public Component, public IBridgeServices {
   // User-configured custom ERDs to poll in addition to the standard list.
   // Populated by add_custom_erd() calls generated from the YAML custom_erds option.
   // Fixed-capacity array to avoid heap allocation.
-  static constexpr uint16_t CUSTOM_ERDS_MAX = 64;
+  static constexpr uint16_t CUSTOM_ERDS_MAX = 128;
   tiny_erd_t custom_erds_[CUSTOM_ERDS_MAX];
   uint16_t custom_erds_count_{0};
 

--- a/docs/spec/geappliances_bridge.md
+++ b/docs/spec/geappliances_bridge.md
@@ -133,7 +133,7 @@ Key member variables:
 | `device_identity_manager_` | `DeviceIdentityManager` | Device ID generation |
 | `feature_bit_manager_` | `FeatureBitManager` | Feature bit reading |
 | `timer_group_` | `tiny_timer_group_t` | Shared timer group |
-| `custom_erds_[CUSTOM_ERDS_MAX]` | `tiny_erd_t[64]` | User-configured custom ERDs |
+| `custom_erds_[CUSTOM_ERDS_MAX]` | `tiny_erd_t[128]` | User-configured custom ERDs |
 | `poll_probe_list_[POLLING_LIST_MAX_SIZE]` | `uint16_t[649]` | Pre-built probe list |
 
 ---

--- a/test/tests/geappliances_bridge_test.cpp
+++ b/test/tests/geappliances_bridge_test.cpp
@@ -20,7 +20,7 @@ using namespace esphome::geappliances_bridge;
 
 // Custom ERD max is defined in the class as protected; duplicate the value here
 // to test capacity without accessing protected members.
-static const uint16_t TEST_CUSTOM_ERDS_MAX = 64;
+static const uint16_t TEST_CUSTOM_ERDS_MAX = 128;
 
 TEST_GROUP(geappliances_bridge)
 {


### PR DESCRIPTION
Doubling the custom ERD limit gives users more headroom for appliances with many ERDs not covered by the feature bit list.

**Files changed:**
- `geappliances_bridge.h` — `CUSTOM_ERDS_MAX` 64 → 128
- `__init__.py` — YAML validation `cv.Length(max=128)`

All 505 tests pass.