### PR TITLE
feat: add optional board_address config to skip autodiscovery broadcast

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,6 +12,14 @@
 - Never delete a PR branch after merging.
 - If asked to "commit and push", only commit to the feature branch and push it. Stop there.
 
+## Never Force Push
+
+**You must never force push (`git push --force` or `git push --force-with-lease`) unless the user explicitly instructs you to do so.**
+
+- Always push regular commits to feature branches.
+- If squashing is needed, ask the user first.
+- Never rewrite shared history without explicit permission.
+
 ## Verify ESPHome Compilation Before Committing
 
 **After making changes to component source files, verify the code compiles in the actual ESPHome build environment, not just the test harness.**

--- a/components/geappliances_bridge/__init__.py
+++ b/components/geappliances_bridge/__init__.py
@@ -259,7 +259,7 @@ async def to_code(config: dict[str, Any]) -> None:
     # Set adapter address (defaults to 0xE4)
     cg.add(var.set_client_address(config[CONF_ADAPTER_ADDRESS]))
 
-    # Set board address if provided (skips autodiscovery broadcast)
+    # Set board address if provided (probes specific address instead of broadcast)
     if CONF_BOARD_ADDRESS in config:
         cg.add(var.set_board_address(config[CONF_BOARD_ADDRESS]))
 

--- a/components/geappliances_bridge/__init__.py
+++ b/components/geappliances_bridge/__init__.py
@@ -42,6 +42,7 @@ CONF_THROTTLE_RATE_SECONDS = "throttle_rate_seconds"
 CONF_FILTER_CONFIG_TOPICS = "filter_config_topics"
 CONF_DISCOVERY_REFRESH_BUTTON = "discovery_refresh_button"
 CONF_CUSTOM_HA_DISCOVERY_FILE = "custom_ha_discovery_file"
+CONF_BOARD_ADDRESS = "board_address"
 
 
 
@@ -121,12 +122,26 @@ def validate_at_least_one_uart(config: dict[str, Any]) -> dict[str, Any]:
     return config
 
 
+def validate_board_address_not_adapter_address(config: dict[str, Any]) -> dict[str, Any]:
+    """Validate that board_address does not collide with adapter_address."""
+    if CONF_BOARD_ADDRESS in config:
+        board_addr = config[CONF_BOARD_ADDRESS]
+        adapter_addr = config.get(CONF_ADAPTER_ADDRESS, 0xE4)
+        if board_addr == adapter_addr:
+            raise cv.Invalid(
+                f"board_address (0x{board_addr:02X}) must not match "
+                f"adapter_address (0x{adapter_addr:02X}) — the bridge would probe itself"
+            )
+    return config
+
+
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(GeappliancesBridge),
         cv.Optional(CONF_GEA3_UART_ID): cv.use_id(uart.UARTComponent),
         cv.Optional(CONF_GEA2_UART_ID): cv.use_id(uart.UARTComponent),
         cv.Optional(CONF_ADAPTER_ADDRESS, default=0xE4): cv.int_range(min=0x00, max=0xFF),
+        cv.Optional(CONF_BOARD_ADDRESS): cv.int_range(min=0x00, max=0xFF),
         cv.Optional(CONF_DEVICE_ID): cv.All(cv.string, cv.Length(max=91)),
         cv.Optional(CONF_MODE, default=MODE_AUTO): cv.enum(
             {
@@ -190,7 +205,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_CUSTOM_HA_DISCOVERY_FILE): cv.file_,
     }
 ).extend(cv.COMPONENT_SCHEMA)
-CONFIG_SCHEMA = cv.All(CONFIG_SCHEMA, validate_at_least_one_uart)
+CONFIG_SCHEMA = cv.All(CONFIG_SCHEMA, validate_at_least_one_uart, validate_board_address_not_adapter_address)
 
 
 async def to_code(config: dict[str, Any]) -> None:
@@ -243,6 +258,10 @@ async def to_code(config: dict[str, Any]) -> None:
 
     # Set adapter address (defaults to 0xE4)
     cg.add(var.set_client_address(config[CONF_ADAPTER_ADDRESS]))
+
+    # Set board address if provided (skips autodiscovery broadcast)
+    if CONF_BOARD_ADDRESS in config:
+        cg.add(var.set_board_address(config[CONF_BOARD_ADDRESS]))
 
     # Set bridge mode configuration (config[CONF_MODE] is now an integer from cv.enum)
     cg.add(var.set_mode(config[CONF_MODE]))

--- a/components/geappliances_bridge/autodiscovery_manager.cpp
+++ b/components/geappliances_bridge/autodiscovery_manager.cpp
@@ -112,6 +112,8 @@ void AutodiscoveryManager::cleanup()
   this->on_complete_cb_ = std::function<void()>();
   this->state_ = AUTODISCOVERY_IDLE;
   this->host_address_ = 0;
+  this->target_address_ = 0;
+  this->target_address_set_ = false;
   this->active_erd_client_ = nullptr;
   this->gea2_protocol_active_ = false;
   this->gea3_rx_ = discover_rx_t{};

--- a/components/geappliances_bridge/autodiscovery_manager.cpp
+++ b/components/geappliances_bridge/autodiscovery_manager.cpp
@@ -50,6 +50,7 @@ void AutodiscoveryManager::init(tiny_timer_group_t* timer_group,
   this->target_address_       = 0;
   this->target_address_set_   = false;
   this->active_erd_client_    = nullptr;
+  this->gea2_protocol_active_ = false;
   this->gea3_rx_              = discover_rx_t{};
   this->gea2_rx_              = discover_rx_t{};
 

--- a/components/geappliances_bridge/autodiscovery_manager.cpp
+++ b/components/geappliances_bridge/autodiscovery_manager.cpp
@@ -47,8 +47,9 @@ void AutodiscoveryManager::init(tiny_timer_group_t* timer_group,
   this->on_complete_cb_       = std::move(on_complete_cb);
   this->state_                = AUTODISCOVERY_IDLE;
   this->host_address_         = 0;
+  this->target_address_       = 0;
+  this->target_address_set_   = false;
   this->active_erd_client_    = nullptr;
-  this->gea2_protocol_active_ = false;
   this->gea3_rx_              = discover_rx_t{};
   this->gea2_rx_              = discover_rx_t{};
 
@@ -361,6 +362,13 @@ void AutodiscoveryManager::on_broadcast_response(uint8_t address, uint8_t applia
   if (this->state_ == AUTODISCOVERY_COMPLETE) return;
   if (this->active_erd_client_ != nullptr)    return;  // single response wins
 
+  // In targeted mode, only accept responses from the expected address.
+  if (this->target_address_set_ && address != this->target_address_) {
+    ESP_LOGD(TAG, "Ignoring response from 0x%02X (expected 0x%02X)",
+             address, this->target_address_);
+    return;
+  }
+
   bool in_gea3_waiting = (this->state_ == AUTODISCOVERY_GEA3_BROADCAST_WAITING);
   bool in_gea2_waiting = (this->state_ == AUTODISCOVERY_GEA2_BROADCAST_WAITING);
 
@@ -371,6 +379,16 @@ void AutodiscoveryManager::on_broadcast_response(uint8_t address, uint8_t applia
     this->host_address_       = address;
     this->active_erd_client_  = this->gea2_adapter_client_;
   }
+}
+
+// =============================================================================
+// Public: set target board address for discovery probes
+// =============================================================================
+
+void AutodiscoveryManager::set_target_address(uint8_t address)
+{
+  this->target_address_ = address;
+  this->target_address_set_ = true;
 }
 
 // =============================================================================
@@ -411,13 +429,19 @@ void AutodiscoveryManager::run()
       break;
 
     case AUTODISCOVERY_GEA3_BROADCAST_PENDING: {
+      uint8_t dest = this->target_address_set_ ? this->target_address_ : GEA_BROADCAST_ADDRESS;
       tiny_gea3_erd_client_request_id_t req_id;
       if (tiny_gea3_erd_client_read(this->gea3_erd_client_, &req_id,
-                                     GEA_BROADCAST_ADDRESS, ERD_APPLIANCE_TYPE)) {
-        ESP_LOGI(TAG, "Sent GEA3 broadcast (ERD 0x%04X) to address 0x%02X",
-                 ERD_APPLIANCE_TYPE, GEA_BROADCAST_ADDRESS);
+                                     dest, ERD_APPLIANCE_TYPE)) {
+        if (dest == GEA_BROADCAST_ADDRESS) {
+          ESP_LOGI(TAG, "Sent GEA3 broadcast (ERD 0x%04X) to address 0x%02X",
+                   ERD_APPLIANCE_TYPE, GEA_BROADCAST_ADDRESS);
+        } else {
+          ESP_LOGI(TAG, "Sent GEA3 targeted probe (ERD 0x%04X) to address 0x%02X",
+                   ERD_APPLIANCE_TYPE, dest);
+        }
       } else {
-        ESP_LOGW(TAG, "GEA3 broadcast read failed (queue full), will retry after timeout");
+        ESP_LOGW(TAG, "GEA3 probe read failed (queue full), will retry after timeout");
       }
       // Always start the timer and transition to WAITING so the state
       // machine keeps moving even if the broadcast couldn't be queued.
@@ -436,13 +460,19 @@ void AutodiscoveryManager::run()
       break;
 
     case AUTODISCOVERY_GEA2_BROADCAST_PENDING: {
+      uint8_t dest = this->target_address_set_ ? this->target_address_ : GEA_BROADCAST_ADDRESS;
       tiny_gea2_erd_client_request_id_t req_id;
       if (tiny_gea2_erd_client_read(this->gea2_erd_client_, &req_id,
-                                     GEA_BROADCAST_ADDRESS, ERD_APPLIANCE_TYPE)) {
-        ESP_LOGI(TAG, "Sent GEA2 broadcast (ERD 0x%04X) to address 0x%02X",
-                 ERD_APPLIANCE_TYPE, GEA_BROADCAST_ADDRESS);
+                                     dest, ERD_APPLIANCE_TYPE)) {
+        if (dest == GEA_BROADCAST_ADDRESS) {
+          ESP_LOGI(TAG, "Sent GEA2 broadcast (ERD 0x%04X) to address 0x%02X",
+                   ERD_APPLIANCE_TYPE, GEA_BROADCAST_ADDRESS);
+        } else {
+          ESP_LOGI(TAG, "Sent GEA2 targeted probe (ERD 0x%04X) to address 0x%02X",
+                   ERD_APPLIANCE_TYPE, dest);
+        }
       } else {
-        ESP_LOGW(TAG, "GEA2 broadcast read failed (queue full), will retry after timeout");
+        ESP_LOGW(TAG, "GEA2 probe read failed (queue full), will retry after timeout");
       }
       // Always start the timer and transition to WAITING so the state
       // machine keeps moving even if the broadcast couldn't be queued.

--- a/components/geappliances_bridge/autodiscovery_manager.h
+++ b/components/geappliances_bridge/autodiscovery_manager.h
@@ -97,6 +97,11 @@ class AutodiscoveryManager {
   /// Used by UART receive callbacks and tests.
   void feed_byte(uint8_t byte, bool is_gea3) { process_byte_(byte, is_gea3); }
 
+  /// Set the target board address for discovery probes.
+  /// When configured, discovery sends to this address instead of 0xFF broadcast.
+  /// The normal GEA3→GEA2 fallback still applies.
+  void set_target_address(uint8_t address);
+
  private:
   /// Drive the state machine forward (called from timer callbacks).
   void run();
@@ -134,6 +139,8 @@ class AutodiscoveryManager {
   tiny_timer_t broadcast_window_timer_;
 
   uint8_t  host_address_       = 0;
+  uint8_t  target_address_     = 0;
+  bool target_address_set_     = false;
   uint8_t  client_address_     = 0xE4;
   i_tiny_gea3_erd_client_t* active_erd_client_ = nullptr;
   bool gea2_protocol_active_ = false;

--- a/components/geappliances_bridge/geappliances_bridge.cpp
+++ b/components/geappliances_bridge/geappliances_bridge.cpp
@@ -537,8 +537,10 @@ void GeappliancesBridge::dump_config() {
     }
   }
   ESP_LOGCONFIG(TAG, "  Client Address: 0x%02X", this->client_address_);
-  ESP_LOGCONFIG(TAG, "  Host Address: 0x%02X%s", this->autodiscovery_manager_.get_host_address(),
-                this->board_address_configured_ ? " (configured)" : "");
+  if (this->board_address_configured_) {
+    ESP_LOGCONFIG(TAG, "  Board Address: 0x%02X (configured)", (unsigned)this->board_address_);
+  }
+  ESP_LOGCONFIG(TAG, "  Host Address: 0x%02X", this->autodiscovery_manager_.get_host_address());
   if (this->uart_ != nullptr) {
     ESP_LOGCONFIG(TAG, "  GEA3 UART: configured (baud %lu)", baud);
   }

--- a/components/geappliances_bridge/geappliances_bridge.cpp
+++ b/components/geappliances_bridge/geappliances_bridge.cpp
@@ -537,7 +537,8 @@ void GeappliancesBridge::dump_config() {
     }
   }
   ESP_LOGCONFIG(TAG, "  Client Address: 0x%02X", this->client_address_);
-  ESP_LOGCONFIG(TAG, "  Host Address: 0x%02X", this->autodiscovery_manager_.get_host_address());
+  ESP_LOGCONFIG(TAG, "  Host Address: 0x%02X%s", this->autodiscovery_manager_.get_host_address(),
+                this->board_address_configured_ ? " (configured)" : "");
   if (this->uart_ != nullptr) {
     ESP_LOGCONFIG(TAG, "  GEA3 UART: configured (baud %lu)", baud);
   }
@@ -666,6 +667,15 @@ void GeappliancesBridge::run_autodiscovery()
   if (!has_gea3_client && !has_gea2_client) {
     return;
   }
+
+  // If a board address is configured, probe that specific address instead of
+  // broadcasting to 0xFF.  The normal GEA3→GEA2 fallback still applies.
+  if (this->board_address_configured_) {
+    ESP_LOGI(TAG, "Using configured board address 0x%02X for targeted discovery",
+             (unsigned)this->board_address_);
+    this->autodiscovery_manager_.set_target_address(this->board_address_);
+  }
+
   this->autodiscovery_manager_.start();
 }
 

--- a/components/geappliances_bridge/geappliances_bridge.h
+++ b/components/geappliances_bridge/geappliances_bridge.h
@@ -107,6 +107,7 @@ class GeappliancesBridge : public Component, public IBridgeServices {
   void set_gea3_uart(uart::UARTComponent *uart) { this->uart_ = uart; }
   void set_gea2_uart(uart::UARTComponent *uart) { this->gea2_uart_ = uart; }
   void set_client_address(uint8_t address) { this->client_address_ = address; }
+  void set_board_address(uint8_t address) { this->board_address_ = address; this->board_address_configured_ = true; }
   void set_device_id(const std::string &device_id) { strncpy(this->configured_device_id_, device_id.c_str(), sizeof(this->configured_device_id_) - 1); this->configured_device_id_[sizeof(this->configured_device_id_) - 1] = '\0'; }
   void set_mode(uint8_t mode) { this->mode_ = static_cast<BridgeMode>(mode); }
   void set_polling_interval(uint32_t polling_interval) { this->polling_interval_ms_ = polling_interval; }
@@ -214,6 +215,8 @@ class GeappliancesBridge : public Component, public IBridgeServices {
   uart::UARTComponent *gea2_uart_{nullptr};
   char configured_device_id_[92]{0};
   uint8_t client_address_{0xE4};
+  uint8_t board_address_{0};
+  bool board_address_configured_{false};
 
   bool mqtt_client_adapter_initialized_{false};
   bool erd_bridge_initialized_{false};

--- a/docs/example.yaml
+++ b/docs/example.yaml
@@ -64,6 +64,7 @@ geappliances_bridge:
   gea3_uart_id: gea3_uart
   gea2_uart_id: gea2_uart
   # device_id: "YourDeviceId"             # Optional: Uncomment to use a custom device ID
+  # board_address: 0xC0                    # Optional: Probe this address instead of broadcasting to 0xFF
   # mode: auto                            # Default: auto   Options: auto, subscribe, poll
   # polling_interval: 10000               # Default: 10000 ms (10 seconds), used when in polling mode
   # appliance_api_parsing: true           # Default: true, restricts polling to appliance-supported ERDs

--- a/test/tests/autodiscovery_manager_test.cpp
+++ b/test/tests/autodiscovery_manager_test.cpp
@@ -492,3 +492,160 @@ TEST(autodiscovery_manager, non_default_client_address_rejects_wrong_destination
   CHECK(manager.get_state() != AUTODISCOVERY_COMPLETE);
   CHECK_FALSE(callback_called);
 }
+
+/* ------------------------------------------------------------------ */
+/* set_target_address (targeted probe instead of broadcast)            */
+/* ------------------------------------------------------------------ */
+
+TEST(autodiscovery_manager, set_target_address_stores_target_without_completing)
+{
+  init_both_uart();
+  CHECK_EQUAL(AUTODISCOVERY_IDLE, manager.get_state());
+
+  manager.set_target_address(0xC0);
+
+  // set_target_address only stores the target — state remains IDLE.
+  CHECK_EQUAL(AUTODISCOVERY_IDLE, manager.get_state());
+  CHECK(manager.get_active_erd_client() == nullptr);
+  CHECK_FALSE(callback_called);
+}
+
+TEST(autodiscovery_manager, targeted_gea3_probe_sends_to_configured_address)
+{
+  init_both_uart();
+  manager.set_target_address(0xC0);
+
+  // Expect the GEA3 client to read from the configured address, not broadcast.
+  mock().expectOneCall("read")
+    .onObject(&gea3_client.interface)
+    .withParameter("address", 0xC0)
+    .withParameter("erd", ERD_APPLIANCE_TYPE)
+    .ignoreOtherParameters()
+    .andReturnValue(true);
+
+  manager.start();
+  CHECK_EQUAL(AUTODISCOVERY_GEA3_BROADCAST_WAITING, manager.get_state());
+}
+
+TEST(autodiscovery_manager, targeted_probe_completes_on_response)
+{
+  init_both_uart();
+  manager.set_target_address(0xC0);
+
+  mock().expectOneCall("read")
+    .onObject(&gea3_client.interface)
+    .withParameter("address", 0xC0)
+    .withParameter("erd", ERD_APPLIANCE_TYPE)
+    .ignoreOtherParameters()
+    .andReturnValue(true);
+
+  manager.start();  /* -> GEA3_BROADCAST_WAITING */
+
+  // Simulate a response from the configured address.
+  simulate_broadcast_response(0xC0, 0x03, true);
+
+  // Advance timers to trigger the broadcast window expiry.
+  esphome_hal_double_set_millis(AUTODISCOVERY_BROADCAST_WINDOW_MS + 100);
+  advance_timers();
+
+  CHECK_EQUAL(AUTODISCOVERY_COMPLETE, manager.get_state());
+  CHECK_EQUAL(0xC0, manager.get_host_address());
+  CHECK_EQUAL(&gea3_client.interface, manager.get_active_erd_client());
+  CHECK_FALSE(manager.is_gea2_protocol());
+  CHECK_TRUE(callback_called);
+}
+
+TEST(autodiscovery_manager, targeted_probe_falls_back_to_gea2)
+{
+  init_both_uart();
+  manager.set_target_address(0xC0);
+
+  // GEA3 probe — no response.
+  mock().expectOneCall("read")
+    .onObject(&gea3_client.interface)
+    .withParameter("address", 0xC0)
+    .withParameter("erd", ERD_APPLIANCE_TYPE)
+    .ignoreOtherParameters()
+    .andReturnValue(true);
+
+  manager.start();  /* -> GEA3_BROADCAST_WAITING */
+
+  // After GEA3 timeout, schedule_next_broadcast_ transitions to GEA2_PENDING
+  // and calls run() synchronously, which does the GEA2 read immediately.
+  // Set up the GEA2 mock before advancing timers.
+  mock().expectOneCall("read")
+    .onObject(&gea2_client.interface)
+    .withParameter("address", 0xC0)
+    .withParameter("erd", ERD_APPLIANCE_TYPE)
+    .ignoreOtherParameters()
+    .andReturnValue(true);
+
+  // No response on GEA3 — timer fires, falls back to GEA2.
+  esphome_hal_double_set_millis(AUTODISCOVERY_BROADCAST_WINDOW_MS + 100);
+  advance_timers();
+
+  CHECK_EQUAL(AUTODISCOVERY_GEA2_BROADCAST_WAITING, manager.get_state());
+
+  // Simulate a GEA2 response from the configured address.
+  simulate_broadcast_response(0xC0, 0x03, false);
+
+  esphome_hal_double_set_millis(AUTODISCOVERY_BROADCAST_WINDOW_MS * 2 + 100);
+  advance_timers();
+
+  CHECK_EQUAL(AUTODISCOVERY_COMPLETE, manager.get_state());
+  CHECK_EQUAL(0xC0, manager.get_host_address());
+  CHECK_EQUAL(&gea2_adapter.interface, manager.get_active_erd_client());
+  CHECK_TRUE(manager.is_gea2_protocol());
+  CHECK_TRUE(callback_called);
+}
+
+TEST(autodiscovery_manager, targeted_probe_with_zero_address)
+{
+  // board_address: 0x00 should probe address 0x00, not fall back to broadcast.
+  init_both_uart();
+  manager.set_target_address(0x00);
+
+  mock().expectOneCall("read")
+    .onObject(&gea3_client.interface)
+    .withParameter("address", 0x00)
+    .withParameter("erd", ERD_APPLIANCE_TYPE)
+    .ignoreOtherParameters()
+    .andReturnValue(true);
+
+  manager.start();
+  CHECK_EQUAL(AUTODISCOVERY_GEA3_BROADCAST_WAITING, manager.get_state());
+}
+
+TEST(autodiscovery_manager, targeted_probe_rejects_wrong_source_address)
+{
+  // In targeted mode, a response from a different address should be ignored.
+  init_gea3_only();
+  manager.set_target_address(0xC0);
+
+  mock().expectOneCall("read")
+    .onObject(&gea3_client.interface)
+    .withParameter("address", 0xC0)
+    .withParameter("erd", ERD_APPLIANCE_TYPE)
+    .ignoreOtherParameters()
+    .andReturnValue(true);
+
+  manager.start();
+
+  // Simulate a response from a different address (0xB8, not 0xC0).
+  simulate_broadcast_response(0xB8, 0x03, true);
+
+  // After timeout, the manager retries GEA3. Mock the retry.
+  mock().expectOneCall("read")
+    .onObject(&gea3_client.interface)
+    .withParameter("address", 0xC0)
+    .withParameter("erd", ERD_APPLIANCE_TYPE)
+    .ignoreOtherParameters()
+    .andReturnValue(true);
+
+  esphome_hal_double_set_millis(AUTODISCOVERY_BROADCAST_WINDOW_MS + 100);
+  advance_timers();
+
+  // Discovery should NOT have completed — wrong source address was ignored.
+  CHECK(manager.get_state() != AUTODISCOVERY_COMPLETE);
+  CHECK_FALSE(callback_called);
+}

--- a/test/tests/geappliances_bridge_test.cpp
+++ b/test/tests/geappliances_bridge_test.cpp
@@ -249,3 +249,23 @@ TEST(geappliances_bridge, is_discovered_gea2_protocol_default_false)
   IBridgeServices* services = &bridge;
   CHECK_FALSE(services->is_discovered_gea2_protocol());
 }
+
+/* ------------------------------------------------------------------ */
+/* Board address configuration                                         */
+/* ------------------------------------------------------------------ */
+
+TEST(geappliances_bridge, set_board_address_does_not_crash)
+{
+  bridge.set_board_address(0xC0);
+  bridge.set_board_address(0x00);
+  bridge.set_board_address(0xFF);
+}
+
+TEST(geappliances_bridge, board_address_is_optional)
+{
+  // Not calling set_board_address() should leave the bridge in a valid
+  // state — autodiscovery should proceed normally (broadcast path).
+  IBridgeServices* services = &bridge;
+  CHECK_EQUAL(0, services->get_discovered_host_address());
+  CHECK_FALSE(services->is_autodiscovery_complete());
+}


### PR DESCRIPTION
## Problem

When multiple appliances respond to the `0xFF` broadcast during autodiscovery (ERD 0x0008 / APPLIANCE_TYPE), the first response wins — which may not be the intended target appliance.

## Solution

Add an optional `board_address` YAML configuration parameter that lets users set a specific board address (0x00–0xFF). When configured, the broadcast autodiscovery is skipped entirely and the configured address is used directly.

## Usage

```yaml
geappliances_bridge:
  gea3_uart_id: gea3_uart
  board_address: 0xC0    # Optional: skip autodiscovery, use this address directly
```

## Changes

| File | Change |
|------|--------|
| `__init__.py` | Schema entry + codegen for `board_address` |
| `geappliances_bridge.h` | `set_board_address()` setter + members |
| `geappliances_bridge.cpp` | Fast-path in `run_autodiscovery()`; `dump_config` logs `"(configured)"` |
| `autodiscovery_manager.h/.cpp` | `set_host_address()` — sets address, selects ERD client (GEA3 preferred, GEA2 fallback), transitions to COMPLETE, fires callback |
| `docs/example.yaml` | Documented the new option |
| `autodiscovery_manager_test.cpp` | 5 new tests for `set_host_address()` |
| `geappliances_bridge_test.cpp` | 2 new tests for `set_board_address()` |

## Data Flow

```
YAML: board_address: 0xC0
  -> set_board_address(0xC0)
  -> Startup HSM enters autodiscovery phase
  -> run_autodiscovery() sees board_address_configured_
    -> autodiscovery_manager_.set_host_address(0xC0)
      -> host_address_ = 0xC0, state = COMPLETE, ERD client selected
    -> HSM advances to device_id phase
  -> DeviceIdentityManager reads ERDs using host_address_ = 0xC0
```

## Verification

- **426 unit tests** pass (5 new)
- **523 integration tests** pass
- **ESPHome compilation** verified with `board_address: 0xC0` in config