### PR TITLE
fix: pin MQTT publisher task to Core 1 for dual-core safety

### DIFF
--- a/HARDWARE.md
+++ b/HARDWARE.md
@@ -84,8 +84,8 @@ uart:
 
 All architectural decisions in this component are driven by the single-core, no-PSRAM constraints of the ESP32-C3:
 
-- **No dual-core concurrency.** The ESP32-C3 and ESP32-C6 each have a single CPU core. FreeRTOS tasks share the core through preemptive context switches — they never run in parallel. Synchronization primitives (`state_mutex`, `done_semaphore`) protect against torn reads/writes during context switches, not against true parallel access.
-- **No PSRAM.** All data structures, buffers, and task stacks must fit in the 320 KB of on-chip SRAM shared with the OS and ESPHome framework. This is why the MQTT publisher task uses a statically allocated 2 KB stack (`xTaskCreateStatic`) and why ERD data is hex-encoded into fixed-size buffers.
+- **No dual-core concurrency on C3/C6.** The ESP32-C3 and ESP32-C6 each have a single CPU core. FreeRTOS tasks share the core through preemptive context switches — they never run in parallel. On dual-core ESP32-S3 the MQTT publisher task is pinned to Core 1 (same core as ESPHome's main loop) to prevent parallel access to shared state without locking. Synchronization primitives (`state_mutex`, `done_semaphore`) protect against torn reads/writes during context switches on all platforms.
+- **No PSRAM.** All data structures, buffers, and task stacks must fit in the 320 KB of on-chip SRAM shared with the OS and ESPHome framework. This is why the MQTT publisher task uses a statically allocated 2 KB stack (`xTaskCreateStaticPinnedToCore` on dual-core, `xTaskCreateStatic` on single-core) and why ERD data is hex-encoded into fixed-size buffers.
 - **DRAM budget:** ~275 KB of 320 KB total. ESPHome's core services (WiFi, MQTT, HTTP) consume ~100 KB of DRAM. The bridge component targets ~175 KB maximum, leaving headroom for the OS and future features.
 - **Flash budget:** ~1.5 MB of 1.8 MB app partition. Any new embedded data must be balanced against this ceiling.
 

--- a/components/geappliances_bridge/erd_cache.h
+++ b/components/geappliances_bridge/erd_cache.h
@@ -12,7 +12,7 @@
  * the background MQTT publisher task. On dual-core ESP32 the publisher
  * is pinned to Core 1 (same core as ESPHome's main loop task) via
  * xTaskCreateStaticPinnedToCore, so both access paths run on the same
- * core and cannot execute concurrently. No mutex is needed. */
+ * core and cannot execute in parallel. No mutex is needed. */
 
 #ifndef erd_cache_h
 #define erd_cache_h
@@ -103,7 +103,7 @@ static inline void erd_cache_mark_unpublished(erd_cache_t* self, erd_cache_entry
  *
  * Thread safety: see erd_cache_mark_published() above.  On dual-core ESP32 both the
  * publisher task and the main loop run on Core 1 (task is pinned), so they cannot
- * execute concurrently. tick_cooldowns touches entries with update_required=true;
+ * execute in parallel. tick_cooldowns touches entries with update_required=true;
  * mark_published touches entries whose update_required was just cleared — disjoint sets. */
 static inline void erd_cache_tick_cooldowns(erd_cache_t* self) {
   if (self->max_cooldown == 0) return;

--- a/components/geappliances_bridge/erd_cache.h
+++ b/components/geappliances_bridge/erd_cache.h
@@ -7,7 +7,12 @@
  * (GEA3 max payload) are rejected. ERD size is invariant after registration —
  * updates are in-place memcpy with no allocation or deallocation. Change
  * detection is done at insert/update time, eliminating per-read memcmp overhead.
- */
+ *
+ * Thread safety: The cache is accessed from both the main loop and
+ * the background MQTT publisher task. On dual-core ESP32 the publisher
+ * is pinned to Core 1 (same core as ESPHome's main loop task) via
+ * xTaskCreateStaticPinnedToCore, so both access paths run on the same
+ * core and cannot execute concurrently. No mutex is needed. */
 
 #ifndef erd_cache_h
 #define erd_cache_h
@@ -70,9 +75,11 @@ void erd_cache_set_throttle_rate_seconds(erd_cache_t* self, uint8_t rate);
  * Static inline — zero overhead when max_cooldown is 0 (early return).
  *
  * Thread safety: with the ESP-IDF framework this is called from the background MQTT publisher
- * task while tick_cooldowns() runs from the main loop.  On single-core ESP32
- * uint8_t access is atomic and the tick→signal_work ordering in loop() ensures
- * the tick always runs before the task drains, so no additional locking is needed. */
+ * task while tick_cooldowns() runs from the main loop.  On dual-core ESP32 the publisher
+ * is pinned to Core 1 (same core as ESPHome's main loop) via
+ * xTaskCreateStaticPinnedToCore, so both access paths run on the same core.
+ * The tick→signal_work ordering in loop() ensures the tick always runs before
+ * the task drains. No additional locking is needed. */
 static inline void erd_cache_mark_published(erd_cache_t* self, erd_cache_entry_t* entry) {
   if (self->max_cooldown == 0 || entry == NULL) return;
   entry->publish_cooldown = self->max_cooldown;
@@ -94,9 +101,10 @@ static inline void erd_cache_mark_unpublished(erd_cache_t* self, erd_cache_entry
 /* Decrement publish_cooldown for all entries with update_required=true.
  * Call once per second. Static inline — zero overhead when max_cooldown is 0.
  *
- * Thread safety: see erd_cache_mark_published() above.  This only touches
- * entries with update_required=true; mark_published() only touches entries
- * whose update_required was just cleared, so they operate on disjoint sets. */
+ * Thread safety: see erd_cache_mark_published() above.  On dual-core ESP32 both the
+ * publisher task and the main loop run on Core 1 (task is pinned), so they cannot
+ * execute concurrently. tick_cooldowns touches entries with update_required=true;
+ * mark_published touches entries whose update_required was just cleared — disjoint sets. */
 static inline void erd_cache_tick_cooldowns(erd_cache_t* self) {
   if (self->max_cooldown == 0) return;
   for (uint16_t i = 0; i < ERD_CACHE_CAPACITY; i++) {

--- a/components/geappliances_bridge/erd_cache_mqtt_publisher.cpp
+++ b/components/geappliances_bridge/erd_cache_mqtt_publisher.cpp
@@ -40,7 +40,10 @@ static void mqtt_publisher_task(void* arg)
 
     // Acquire mutex to safely read shared state (mqtt_connected, cache pointers,
     // publish_index) and protect the entire drain loop. These fields can be
-    // modified by the main loop during context switches.
+    // modified by the main loop during preemptive context switches. The mutex
+    // protects against interleaving on the same core — cross-core parallelism
+    // is prevented by pinning both tasks to Core 1 (dual-core) or by
+    // single-core hardware (C3, C6).
     bool connected = false;
     bool has_deps = false;
     bool paused = false;

--- a/components/geappliances_bridge/erd_cache_mqtt_publisher.cpp
+++ b/components/geappliances_bridge/erd_cache_mqtt_publisher.cpp
@@ -221,6 +221,15 @@ void erd_cache_mqtt_publisher_start(erd_cache_mqtt_publisher_t* self)
   if (self->task_handle != NULL) return; // already running
   if (self->work_semaphore == NULL) return; // semaphore creation failed in init
   self->task_running = true;
+  /* Pin the publisher task to the same core as ESPHome's main loop.
+   * ESPHome pins its loop task to Core 1 on dual-core ESP32
+   * (esphome/components/esp32/core.cpp: xTaskCreateStaticPinnedToCore(..., 1)).
+   * On dual-core ESP32-S3 the erd_cache_t is accessed from both the
+   * main loop and this task.  The cache has no mutex — thread safety
+   * relies on single-core ordering (tick → signal_work → drain).
+   * Running on the same core as the main loop restores that guarantee.
+   * On single-core chips (C3, C6) the coreID is ignored. */
+#if CONFIG_FREERTOS_UNICORE
   self->task_handle = xTaskCreateStatic(
       mqtt_publisher_task,
       "erd_mqtt_pub",
@@ -229,6 +238,17 @@ void erd_cache_mqtt_publisher_start(erd_cache_mqtt_publisher_t* self)
       2,
       self->task_stack,
       &self->task_tcb);
+#else
+  self->task_handle = xTaskCreateStaticPinnedToCore(
+      mqtt_publisher_task,
+      "erd_mqtt_pub",
+      2048 / sizeof(StackType_t),  /* words, matching task_stack[] size */
+      self,
+      2,
+      self->task_stack,
+      &self->task_tcb,
+      1);  /* Core 1 — same core as ESPHome's main loop task */
+#endif
   if (self->task_handle == NULL) {
     ESP_LOGE(PUBLISHER_TAG, "Failed to create MQTT publisher task");
     self->task_running = false;

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -196,7 +196,9 @@ a round-robin index, ensuring fair distribution across all ERDs.
 ### Round-robin publishing with background task
 
 Publishing runs in a dedicated FreeRTOS background task created with
-`xTaskCreateStatic` (zero heap allocation). The task blocks on a binary semaphore
+`xTaskCreateStaticPinnedToCore` on dual-core ESP32 (pinned to Core 1,
+matching ESPHome's main loop) or `xTaskCreateStatic` on single-core
+(zero heap allocation in both cases). The task blocks on a binary semaphore
 signaled by the main loop, acquires a state mutex to safely read shared fields,
 publishes one entry per wake, then releases the mutex. Pre-allocated buffers on
 the struct avoid stack overflow. On MQTT disconnect the publisher pauses; on

--- a/docs/module_descriptions/erd_cache_mqtt_publisher.md
+++ b/docs/module_descriptions/erd_cache_mqtt_publisher.md
@@ -26,8 +26,7 @@ Scans the shared ERD cache and publishes updated ERDs to MQTT topics with `retai
 
 ### ESP-IDF: Background Task
 
-On ESP-IDF, the publisher runs as a FreeRTOS task (`erd_mqtt_pub`) with:
-- **Stack**: 2048 bytes (static allocation via `xTaskCreateStatic`)
+- **Stack**: 2048 bytes (static allocation via `xTaskCreateStaticPinnedToCore` on dual-core ESP32, `xTaskCreateStatic` on single-core)
 - **Priority**: 2
 - **Scheduling**: Blocks on `work_semaphore` with `portMAX_DELAY` (no timeout). The main loop controls pacing via `erd_cache_mqtt_publisher_signal_work()`.
 

--- a/docs/spec/erd_cache_mqtt_publisher.md
+++ b/docs/spec/erd_cache_mqtt_publisher.md
@@ -77,7 +77,7 @@ On ESP-IDF:
 - Guard against already-running task (`task_handle != NULL`)
 - Guard against failed semaphore creation (`work_semaphore == NULL`)
 - Set `task_running = true`
-- Create the static task via `xTaskCreateStatic()` with 2048-byte stack, priority 2, name `"erd_mqtt_pub"`
+- Create the static task via `xTaskCreateStaticPinnedToCore()` (Core 1, dual-core) or `xTaskCreateStatic()` (single-core) with 2048-byte stack, priority 2, name `"erd_mqtt_pub"`
 - On task creation failure: log error, set `task_running = false`
 
 On non-ESP-IDF: no-op.
@@ -117,7 +117,7 @@ On non-ESP-IDF: no-op.
 
 On ESP-IDF, the publisher runs as a FreeRTOS task (`mqtt_publisher_task`) with:
 
-- **Stack**: 2048 bytes, statically allocated via `xTaskCreateStatic` (no heap allocation)
+- **Stack**: 2048 bytes, statically allocated via `xTaskCreateStaticPinnedToCore` on dual-core or `xTaskCreateStatic` on single-core (no heap allocation)
 - **Priority**: 2
 - **Name**: `"erd_mqtt_pub"`
 - **Scheduling**: Blocks on `work_semaphore` with `portMAX_DELAY` (no timeout). The main loop controls pacing by calling `erd_cache_mqtt_publisher_signal_work()` when cache entries are updated.

--- a/test/include/esp-idf/freertos_stub.h
+++ b/test/include/esp-idf/freertos_stub.h
@@ -44,6 +44,13 @@ static inline TaskHandle_t xTaskCreateStatic(void (*fn)(void*), const char* name
     (void)stack_buf; (void)tcb;
     return (TaskHandle_t)0x1;
 }
+static inline TaskHandle_t xTaskCreateStaticPinnedToCore(void (*fn)(void*), const char* name,
+        uint32_t stack, void* arg, UBaseType_t prio,
+        StackType_t* stack_buf, StaticTask_t* tcb, BaseType_t core) {
+    (void)fn; (void)name; (void)stack; (void)arg; (void)prio;
+    (void)stack_buf; (void)tcb; (void)core;
+    return (TaskHandle_t)0x1;
+}
 
 /* ---------- queue.h types & functions ---------- */
 typedef void* QueueHandle_t;


### PR DESCRIPTION
On ESP32-S3 (dual-core), the background erd_cache_mqtt_publisher task was created without core affinity, allowing FreeRTOS to schedule it on Core 0. This raced with the main loop on Core 0 accessing the shared erd_cache_t arena concurrently without locking — producing corrupted MQTT payloads and intermittent crashes.

Pin the publisher to Core 1 via xTaskCreateStaticPinnedToCore so both access paths run on the same core, restoring the single-core ordering guarantees the cache relies on (tick → signal_work → drain).

xTaskCreateStaticPinnedToCore(..., 1) is safe on single-core chips (C3, C6) — the coreID parameter is ignored when configNUMBER_OF_CORES=1.

- erd_cache_mqtt_publisher.cpp: use xTaskCreateStaticPinnedToCore
- erd_cache.h: update thread-safety comments to document core pinning
- freertos_stub.h: add xTaskCreateStaticPinnedToCore stub for tests